### PR TITLE
chore: release v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferriby"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "color-eyre",

--- a/ferriby/CHANGELOG.md
+++ b/ferriby/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/dawedawe/ferriby/compare/v0.1.1...v0.1.2) - 2025-07-06
+
+### Other
+
+- release v0.1.1
+
 ## [0.1.1](https://github.com/dawedawe/ferriby/releases/tag/v0.1.1) - 2025-07-06
 
 ### Added

--- a/ferriby/Cargo.toml
+++ b/ferriby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferriby"
-version = "0.1.1"
+version = "0.1.2"
 description = "keep ferris alive by contributing to a git repo"
 readme = "../README.md"
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `ferriby`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/dawedawe/ferriby/compare/v0.1.1...v0.1.2) - 2025-07-06

### Other

- release v0.1.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).